### PR TITLE
Add CLAUDE.md template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,16 +53,19 @@ A brief description of the project, its purpose, and key goals.
 
 ```bash
 # Build command
-[build command]
+[command]
 
 # Test command
-[test command]
+[command]
 
 # Lint command
-[lint command]
+[command]
+
+# Check command
+[command]
 
 # Development server
-[dev server command]
+[command]
 ```
 
 ## Project Structure
@@ -75,23 +78,13 @@ Key directories and their purpose:
 
 ## Review Process Guidelines
 
-ALWAYS follow these steps when reviewing code:
+Before submitting any code, ensure the following steps are completed:
 
-1. **Check CLAUDE.md standards first**:
+1. **Run all lint, check and test commands**
 
-   ```bash
-   [lint command]
-   ```
+2. **Review outputs and iterate until all issues are resolved**
 
-2. **Run all checks**:
-
-   ```bash
-   [check command]
-   ```
-
-3. **Review outputs and iterate until all issues are resolved**
-
-4. **Assess compliance**:
+3. **Assess compliance**:
    For each standard, explicitly state ✅ or ❌ and explain why:
 
    - Code style and formatting
@@ -101,7 +94,7 @@ ALWAYS follow these steps when reviewing code:
    - Test coverage
    - Documentation
 
-5. **Self-review checklist**:
+4. **Self-review checklist**:
    - [ ] Code follows defined patterns
    - [ ] No debug/commented code
    - [ ] Error handling implemented

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,101 @@
+# Project: [Project Name]
+
+## Project Overview
+
+A brief description of the project, its purpose, and key goals.
+
+## Tech Stack
+
+- Languages: [list primary languages]
+- Frameworks: [list frameworks]
+- Tools: [list tools]
+
+## Code Style & Conventions
+
+- Code formatting guidelines
+- Naming conventions
+- Project-specific patterns to follow
+
+## Development Workflow
+
+- Branch strategy
+- Commit message format
+- PR requirements
+
+## Testing Strategy
+
+- Test frameworks
+- Coverage requirements
+- Test naming conventions
+
+## Environment Setup
+
+- Required environment variables
+- Setup commands
+- Local development server
+
+## Common Commands
+
+```bash
+# Build command
+[command]
+
+# Test command
+[command]
+
+# Lint command
+[command]
+```
+
+## Project Structure
+
+Key directories and their purpose:
+
+- `/src` - [description]
+- `/tests` - [description]
+- [other important directories]
+
+## Review Process Guidelines
+
+Before submitting any code, ensure the following steps are completed:
+
+1. Run all lint commands to ensure code style compliance:
+
+   ```bash
+   [lint command]
+   ```
+
+2. Run check commands to validate code quality:
+
+   ```bash
+   [check command]
+   ```
+
+3. Review command outputs thoroughly and iterate until all issues are resolved
+
+4. Verify that the code complies with all standards defined in this document:
+
+   - Code style and formatting standards
+   - Naming conventions
+   - Project-specific patterns
+   - Test coverage requirements
+   - Documentation requirements
+
+5. Self-review checklist:
+   - [ ] Code follows the defined structure and patterns
+   - [ ] No debug code or commented-out code remains
+   - [ ] Error handling is implemented appropriately
+   - [ ] Tests are written and passing
+   - [ ] Documentation is updated
+
+## Known Issues & Workarounds
+
+Document any current limitations or workarounds Claude should be aware of.
+
+## Documentation Guidelines
+
+How documentation should be structured and where it should be placed.
+
+## References
+
+Links to relevant external documentation, design docs, or resources.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ A brief description of the project, its purpose, and key goals.
 
 ## Code Style & Conventions
 
+- Import standards
 - Code formatting guidelines
 - Naming conventions
 - Project-specific patterns to follow
@@ -71,7 +72,7 @@ Before submitting any code, ensure the following steps are completed:
    [check command]
    ```
 
-3. Review command outputs thoroughly and iterate until all issues are resolved
+3. Review outputs and iterate until all issues are resolved
 
 4. Verify that the code complies with all standards defined in this document:
 
@@ -91,10 +92,6 @@ Before submitting any code, ensure the following steps are completed:
 ## Known Issues & Workarounds
 
 Document any current limitations or workarounds Claude should be aware of.
-
-## Documentation Guidelines
-
-How documentation should be structured and where it should be placed.
 
 ## References
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+**IMPORTANT FOR CLAUDE: Reference this file before implementing anything**
+
 # Project: [Project Name]
 
 ## Project Overview
@@ -12,10 +14,22 @@ A brief description of the project, its purpose, and key goals.
 
 ## Code Style & Conventions
 
-- Import standards
-- Code formatting guidelines
-- Naming conventions
-- Project-specific patterns to follow
+### Import/Module Standards
+
+- [Specify import standards]
+
+### Naming Conventions
+
+- [Functions naming convention]
+- [Classes/Components naming convention]
+- [Constants naming convention]
+- [Files naming convention]
+
+### Patterns to Follow
+
+- [Key architectural patterns]
+- [Error handling approaches]
+- [Code organisation principles]
 
 ## Development Workflow
 
@@ -39,13 +53,16 @@ A brief description of the project, its purpose, and key goals.
 
 ```bash
 # Build command
-[command]
+[build command]
 
 # Test command
-[command]
+[test command]
 
 # Lint command
-[command]
+[lint command]
+
+# Development server
+[dev server command]
 ```
 
 ## Project Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,36 +58,38 @@ Key directories and their purpose:
 
 ## Review Process Guidelines
 
-Before submitting any code, ensure the following steps are completed:
+ALWAYS follow these steps when reviewing code:
 
-1. Run all lint commands to ensure code style compliance:
+1. **Check CLAUDE.md standards first**:
 
    ```bash
    [lint command]
    ```
 
-2. Run check commands to validate code quality:
+2. **Run all checks**:
 
    ```bash
    [check command]
    ```
 
-3. Review outputs and iterate until all issues are resolved
+3. **Review outputs and iterate until all issues are resolved**
 
-4. Verify that the code complies with all standards defined in this document:
+4. **Assess compliance**:
+   For each standard, explicitly state ✅ or ❌ and explain why:
 
-   - Code style and formatting standards
+   - Code style and formatting
    - Naming conventions
-   - Project-specific patterns
-   - Test coverage requirements
-   - Documentation requirements
+   - Architecture patterns (refer to `ARCHITECTURE.md`)
+   - Error handling
+   - Test coverage
+   - Documentation
 
-5. Self-review checklist:
-   - [ ] Code follows the defined structure and patterns
-   - [ ] No debug code or commented-out code remains
-   - [ ] Error handling is implemented appropriately
-   - [ ] Tests are written and passing
-   - [ ] Documentation is updated
+5. **Self-review checklist**:
+   - [ ] Code follows defined patterns
+   - [ ] No debug/commented code
+   - [ ] Error handling implemented
+   - [ ] Tests written and passing
+   - [ ] Documentation updated
 
 ## Known Issues & Workarounds
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,0 +1,101 @@
+# Human-AI Pair-Programming: A Rough Guide
+
+## Overview
+
+Build a collaborative Kanban board application using AI-assisted development. Work in human-AI pairs, practice effective prompting, and maintain human oversight throughout the process.
+
+## IQRE Process
+
+Follow these four steps consistently throughout the workshop:
+
+1. **Iterate**: Share ideas/request code from AI and develop specifications or features through iteration.
+2. **Question**: Review AI output, identify gaps, and refine through follow-up questions.
+3. **Review/Create**: Understand generated code/specs. If inspired, create a new, enhanced solution based on AI's output.
+4. **Explain**: Present outputs to teammates, emphasising clear foundations and alignment.
+
+## Workshop Phases
+
+### Conception
+
+- **Pair Formation**: Form teams (1 frontend + 1 backend developer)
+- **Repository Setup**: Fork and clone workshop repository
+- **Specification Development**:
+  - Use GENERATE SPECS prompt collaboratively
+  - Create `FUNCTIONAL.md`, `ARCHITECTURE.md`, `CLAUDE.md`
+  - Use SPEC WRAP-UP prompt
+
+**Output**: Initial documentation pushed to repo
+
+### Environment & Tickets
+
+- **Parallel Setup**:
+  - **Frontend Dev**: Use GENERATE TICKETS prompt to create `TICKETS.md`
+  - **Backend Dev**: Set up environment, frameworks, folder structure, install libraries
+- **Coordination**: Review tickets for dependencies and overlaps
+
+**Output**: Ready-to-code environment with structured tickets
+
+### Implementation
+
+Work on individual machines with separate Claude Code instances.
+
+**Per Ticket Process**:
+
+1. Use KICKOFF/REFRESH MEMORY prompt
+2. Implement features
+3. Use REVIEW prompt after each piece
+4. Use CONTEXT RESET after ticket completion
+
+**Between Sessions**:
+
+- Use PROGRESS SYNC prompt
+- Coordinate dependencies with teammate
+- Update `CLAUDE.md` with learned standards
+
+**Output**: Incremental feature completion with documented PRs
+
+### Context Management
+
+- Use HISTORY\_[NAME].md for context summaries
+- Reset Claude's context window after each ticket
+- Maintain clean workspace
+
+**Output**: Archived context for reference, clean workspace
+
+### Presentation
+
+- Demo Kanban board
+- Show AI collaboration examples
+- Present evolved standards
+- Reflect on deliberate architectural decisions
+
+**Output**: 5-minute presentation with examples and demo
+
+## Key Guidelines
+
+### AI Collaboration
+
+- **Explicit Prompting**: Always tell Claude which files to reference (it won't do this automatically)
+- **Context Management**: Use CONTEXT RESET prompt to maintain clarity
+- **Standards Evolution**: Update `CLAUDE.md` when discovering new patterns
+
+### Team Coordination
+
+- **Sync Regularly**: During designated progress sessions
+- **Check Dependencies**: Use DEPENDENCY CHECK prompt when unclear
+- **Share Learnings**: Document architectural decisions and standard updates
+
+### Quality Assurance
+
+- **Follow IQRE**: Apply the four steps consistently
+- **Review Obsessively**: Use REVIEW prompt religiously
+- **Maintain Standards**: Keep `CLAUDE.md` current and concise
+
+## Success Criteria
+
+- Functional Kanban board with task management
+- Effective AI collaboration patterns
+- Evolved standards documented in `CLAUDE.md`
+- Clear architectural decisions
+
+**Remember**: You're the human-in-the-loop. Guide the AI, don't just accept its output.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -56,7 +56,7 @@ Work on individual machines with separate Claude Code instances.
 
 ### Context Management
 
-- Use HISTORY\_[NAME].md for context summaries
+- Use `HISTORY\_[NAME].md` for context summaries
 - Reset Claude's context window after each ticket
 - Maintain clean workspace
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -16,6 +16,9 @@ These are the prompts you can use to do so:
 
 ### GENERATE SPECS
 
+> [!NOTE]
+> Resist the urge of being too ambitious here, remember you must finish building this and fully understand, be able to explain it by the end of the day. This is _just_ a simple kanban board. The aim is simply to make sure it is built the way you want/dictate.
+
 ```markdown
 We're going to discuss the specification for a software project. I am working in team of 2 people, each pair-programming with an AI (we each have the workshop repo cloned to our machines, and each have an instance of Claude Code running inside that repo) in the context of an AI-assisted development workshop. The project details are contained in `TASK.md` and workshop details are in `README.md`.
 

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -1,9 +1,9 @@
 # Prompts for Claude
 
 > [!IMPORTANT]  
-> There are plenty of variables throughout these prompts which need to be filled before use or if you direct Claude to this document you can indicate what those are. For instance, "Follow 'KICKOFF / REFRESH MEMORY' in PROMPTS.md - fill variables with TICKET_NUMBER=2, NAME='Max' and PROMPT='Create data.json'"
+> There are plenty of variables throughout these prompts which need to be filled before use or if you direct Claude to this document you can indicate what those are. For instance, "Follow 'KICKOFF / REFRESH MEMORY' in `PROMPTS.md` - fill variables with `TICKET_NUMBER=2`, `NAME='Max'` and `PROMPT='Create data.json'`"
 
-## CONCEPTION
+## Conception
 
 The first step is to develop your own set of specifications, requirements and standards for this project. To do this you will converse as a team with Claude and produce 4 structured outputs:
 
@@ -54,7 +54,7 @@ Break the project down into manageable, atomic tickets that:
 - Minimise overlap for simultaneous development
 - Are small enough to complete in one session
 
-Generate TICKETS.md with:
+Generate `TICKETS.md` with:
 
 1. Clear dependencies between tickets
 2. Frontend tickets assigned to [DEV1_NAME]
@@ -72,7 +72,7 @@ Each ticket should include:
 **Important**: Order tickets by dependency, ensuring both developers can work efficiently and logically through the tickets in order, without blocking each other.
 ```
 
-## IMPLEMENTATION
+## Implementation
 
 During implementation, there are a number of prompts you can use at the start of each ticket (KICKOFF / REFRESH MEMORY), after each implementation (REVIEW), after each ticket (CONTEXT RESET) and at specific times during the day (PROGRESS SYNC). Included is also a DEPENDENCY CHECK prompt to be used if anything is unclear, remember to also check in with your teammate regularly to iron out anything that is unclear or overlapping.
 
@@ -154,7 +154,7 @@ After creating/updating these files, I'll reset the context window and we'll con
 > At 3 points during the day, there will be an allocated project sync time, when you can discuss your progress with your team member. To do so, finish what you are doing and send this prompt to get some talking points, your teammate will do the same:
 
 ```markdown
-We're pausing implementation to sync with team. Please:
+We're pausing implementation to sync with team. You will:
 
 1. Summarise what we've completed in this session
 2. Note any important architectural decisions made

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -1,0 +1,166 @@
+# Prompts for Claude
+
+> [!IMPORTANT]  
+> There are plenty of variables throughout these prompts which need to be filled before use or if you direct Claude to this document you can indicate what those are. For instance, "Follow 'KICKOFF / REFRESH MEMORY' in PROMPTS.md - fill variables with TICKET_NUMBER=2, NAME='Max' and PROMPT='Create data.json'"
+
+## CONCEPTION
+
+The first step is to develop your own set of specifications, requirements and standards for this project. To do this you will converse as a team with Claude and produce 4 structured outputs:
+
+1. **FUNCTIONAL.md** - Complete functional requirements
+2. **ARCHITECTURE.md** - Detailed project architecture
+3. **CLAUDE.md** - Compact standards and guidelines
+4. **TICKETS.md** - Ordered tasks/features to complete the project collaboratively
+
+These are the prompts you can use to do so:
+
+### GENERATE SPECS
+
+```markdown
+We're going to discuss the specification for a software project. I am working in team of 2 people, each pair-programming with an AI (we each have the workshop repo cloned to our machines, and each have an instance of Claude Code running inside that repo) in the context of an AI-assisted development workshop. The project details are contained in `TASK.md` and workshop details are in `README.md`.
+
+Ask me one question at a time so we can develop thorough, step-by-step specs. Each question should build on my previous answers, and our end goal is to have a detailed specification I can hand off to a developer. This will be built in only a few hours so try and keep the conversation short, apply KISS principles and use logical inference based on previous answers when possible.
+
+We should cover: frameworks, libraries, package managers, styling choices, data structure options (SQL/NoSQL/Graph) BEFORE data storage, architecture, project structure, components, interfaces, design patterns, error handling, UI features, user experience, coding standards, naming conventions, agreed principles, version control, commit standards, testing and documentation requirements.
+
+Do not wrap up until you have answers from me for each of these topics. There will be three outputs at the end: a functional spec, an architectural spec, and our code standards specification for `CLAUDE.md`, review the template for this file currently in the repo to understand what we must cover.
+
+**Important**: When asking questions about technical choices, present 2-3 specific options with brief explanations rather than leaving it open-ended. This speeds up decision-making. When there are more viable options available, verbalise this and ask if I want to see more options. Only one question at a time, stay within scope, and don't generate anything until requested.
+```
+
+### SPEC WRAP-UP
+
+```markdown
+Now that we've wrapped up the brainstorming process, compile our findings into three comprehensive, developer-ready specifications:
+
+1. **FUNCTIONAL.md** - Complete functional requirements
+2. **ARCHITECTURE.md** - Detailed project architecture
+3. **CLAUDE.md** - Compact standards and guidelines
+
+For `CLAUDE.md`, follow the existing template but ensure each section includes specific, actionable directives that we can reference explicitly during development. Be very concise, this should be a compact standards document you will refer to each time you write any code.
+
+Make each specification modular and cross-referenced so developers can quickly find relevant information when prompted to check these files. Do not repeat yourself.
+```
+
+### GENERATE TICKETS
+
+```markdown
+Review `CLAUDE.md` first to understand our standards. Then review `FUNCTIONAL.md` and `ARCHITECTURE.md` to understand what we're building.
+
+Break the project down into manageable, atomic tickets that:
+
+- Split cleanly between frontend and backend
+- Build on each other logically
+- Minimise overlap for simultaneous development
+- Are small enough to complete in one session
+
+Generate TICKETS.md with:
+
+1. Clear dependencies between tickets
+2. Frontend tickets assigned to [DEV1_NAME]
+3. Backend tickets assigned to [DEV2_NAME]
+4. Explicit prerequisites listed
+
+Each ticket should include:
+
+- Brief description
+- Specific deliverables
+- Dependencies (if any)
+- Assignee
+- Definition of done
+
+**Important**: Order tickets by dependency, ensuring both developers can work efficiently and logically through the tickets in order, without blocking each other.
+```
+
+## IMPLEMENTATION
+
+During implementation, there are a number of prompts you can use at the start of each ticket (KICKOFF / REFRESH MEMORY), after each implementation (REVIEW), after each ticket (CONTEXT RESET) and at specific times during the day (PROGRESS SYNC). Included is also a DEPENDENCY CHECK prompt to be used if anything is unclear, remember to also check in with your teammate regularly to iron out anything that is unclear or overlapping.
+
+### KICKOFF / REFRESH MEMORY
+
+> [!NOTE]
+> Always clear context window before using this prompt. Remove the sentence asking to check `HISTORY_[NAME].md` on kickoff as this will be the first code interaction.
+
+```markdown
+**First, review `CLAUDE.md` to understand our project standards and workflow.**
+
+Then refresh your memory by checking `HISTORY_[NAME].md`. Review the `ARCHITECTURE_PLAN.md` and `FUNCTIONAL_PLAN.md` to understand what we are building.
+
+We are working through `TICKETS.md` and are on ticket [TICKET_NUMBER] (I'm [NAME]).
+
+**Before implementing anything:**
+
+1. Confirm you understand the current ticket requirements
+2. Ask if you should reference any specific standards from `CLAUDE.md`
+3. Only implement what's specified in this ticket
+
+As you implement, explain:
+
+- How the code works and why it meets our `FUNCTIONAL.md` requirements
+- How it aligns with our `ARCHITECTURE.md`
+- Why it complies with our standards in `CLAUDE.md`
+
+Now, [PROMPT]
+```
+
+### DEPENDENCY CHECK
+
+> [!NOTE]
+> Use this prompt if ticket dependencies or scope is unclear or overlapping.
+
+```markdown
+Before starting this ticket, check `TICKETS.md` for dependencies. Then:
+
+1. Verify all prerequisite tickets are complete
+2. Confirm our implementation aligns with dependent tickets
+3. Check if any shared interfaces or data structures need coordination with your teammate
+4. Flag any potential conflicts with work in progress
+
+Only proceed when dependencies are satisfied and coordination is clear.
+```
+
+### REVIEW
+
+> [!NOTE]
+> Use this prompt after each 'piece' of implementation to ensure code consistency and catch errors early.
+
+```markdown
+Review `CLAUDE.md` first, then follow the review process guidelines within. Run the specified checks and assess code compliance against our standards, explaining your findings for each.
+```
+
+### CONTEXT RESET
+
+> [!NOTE]
+> You must use this prompt after each ticket.
+
+```markdown
+Now we will reset the context window, before we do so:
+
+1. Create/update a `HISTORY_[NAME].md` file summarising our progress
+2. List completed tickets with key implementation details
+3. Note any important decisions or patterns established
+4. Mention any deviations from original specs and why
+5. Save current state of key variables/configurations
+6. If applicable, update `CLAUDE.md` with any learned standards picked up from the review process
+7. If there have been significant changes, update `FUNCTIONAL.md` or `ARCHITECTURE.md` as required
+8. **IMPORTANT**: Be concise, don't repeat yourself, double check and remove duplication/reduce where possible
+
+After creating/updating these files, I'll reset the context window and we'll continue with a fresh session.
+```
+
+### PROGRESS SYNC
+
+> [!NOTE]
+> At 3 points during the day, there will be an allocated project sync time, when you can discuss your progress with your team member. To do so, finish what you are doing and send this prompt to get some talking points, your teammate will do the same:
+
+```markdown
+We're pausing implementation to sync with team. Please:
+
+1. Summarise what we've completed in this session
+2. Note any important architectural decisions made
+3. Identify any changes that affect other team members
+4. Highlight any blocks or questions for team discussion
+5. Suggest next logical steps for our pairing
+
+This helps maintain team coherence while each pair works independently.
+```

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -44,6 +44,9 @@ Make each specification modular and cross-referenced so developers can quickly f
 
 ### GENERATE TICKETS
 
+> [!IMPORTANT]  
+> This prompt contains variables `DEV1_NAME` and `DEV2_NAME` to be filled in.
+
 ```markdown
 Review `CLAUDE.md` first to understand our standards. Then review `FUNCTIONAL.md` and `ARCHITECTURE.md` to understand what we're building.
 
@@ -78,8 +81,11 @@ During implementation, there are a number of prompts you can use at the start of
 
 ### KICKOFF / REFRESH MEMORY
 
+> [!IMPORTANT]  
+> This prompt contains variables `NAME`, `TICKET_NUMBER` and `PROMPT` to be filled in. Remove the sentence asking to check `HISTORY_[NAME].md` on first ticket as this will be the first code interaction.
+
 > [!NOTE]
-> Always clear context window before using this prompt. Remove the sentence asking to check `HISTORY_[NAME].md` on kickoff as this will be the first code interaction.
+> Always clear context window before using this prompt.
 
 ```markdown
 **First, review `CLAUDE.md` to understand our project standards and workflow.**
@@ -105,11 +111,14 @@ Now, [PROMPT]
 
 ### DEPENDENCY CHECK
 
+> [!IMPORTANT]  
+> This prompt contains variable `TICKET_NUMBER` to be filled in.
+
 > [!NOTE]
 > Use this prompt if ticket dependencies or scope is unclear or overlapping.
 
 ```markdown
-Before starting this ticket, check `TICKETS.md` for dependencies. Then:
+Before starting this ticket [TICKET_NUMBER], check `TICKETS.md` for dependencies. Then:
 
 1. Verify all prerequisite tickets are complete
 2. Confirm our implementation aligns with dependent tickets


### PR DESCRIPTION
This PR adds a structured CLAUDE.md template to guide Claude Code interactions. The template:
- Defines project standards and conventions
- Establishes review processes and quality checks
- Ensures consistent code generation and modification
- Maintains adherence to our development workflows

EDIT: In addition I've added a `GUIDE.md` to serve as a reference throughout the process and a `PROMPTS.md` that they can refer to for the "major" prompts.